### PR TITLE
error if tty-share isn't found

### DIFF
--- a/src/shwim/cli.py
+++ b/src/shwim/cli.py
@@ -49,6 +49,9 @@ def shwim(code, mailbox, read_only):
     Note that the 'guest' user can type and run commands but the host
     can use --read-only if they don't want this.
     """
+    if not shutil.which("tty-share"):
+        print("shwim requires the 'tty-share' program to be installed and on the $PATH")
+        raise Exception("tty-share not found, is it installed?")
     if code is None:
         react(
             lambda r: ensureDeferred(_host(r, mailbox, read_only))

--- a/src/shwim/cli.py
+++ b/src/shwim/cli.py
@@ -51,7 +51,7 @@ def shwim(code, mailbox, read_only):
     """
     if not shutil.which("tty-share"):
         print("shwim requires the 'tty-share' program to be installed and on the $PATH")
-        raise Exception("tty-share not found, is it installed?")
+        raise click.UsageError("tty-share not found, is it installed?")
     if code is None:
         react(
             lambda r: ensureDeferred(_host(r, mailbox, read_only))


### PR DESCRIPTION
I opened #10 when I first ran shwim without tty-share instaled.

Here's a fix, "error if tty-share not found".

interactive testing implies this works.

```
❯ uv run shwim
shwim requires the 'tty-share' program to be installed and on the $PATH
Usage: shwim [OPTIONS] [CODE]
Try 'shwim --help' for help.

Error: tty-share not found, is it installed?
```

fixes #10 